### PR TITLE
more control over specifying elasticsearch endpoints

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -49,11 +49,11 @@ brooklyn.catalog:
     description: |
        Logstash server to be embedded as a child of a SoftwareProcess who
        publishes his 'log.location' as a sensor.
-       Callers should configure 'logstash.elasticsearch.ip' (if using ES)
+       Callers should configure 'logstash.elasticsearch.host' (if using ES)
        or 'logstash.config.output'.
     item:
       type: logstash-standalone
       brooklyn.config:
         logstash.config.input: $brooklyn:formatString("input { file { path => \"%s\" start_position => \"beginning\" } }", $brooklyn:parent().attributeWhenReady("log.location"))
-        logstash.elasticsearch.ip: 127.0.0.1  # must be supplied by caller!
-        logstash.config.output: $brooklyn:formatString("output { elasticsearch { host => \"%s:9200\" protocol => \"http\" embedded => false } }", $brooklyn:config("logstash.elasticsearch.ip"))
+        logstash.elasticsearch.host: 127.0.0.1:9200  # must be supplied by caller!
+        logstash.config.output: $brooklyn:formatString("output { elasticsearch { host => %s protocol => \"http\" embedded => false } }", $brooklyn:config("logstash.elasticsearch.host"))


### PR DESCRIPTION
Updated blueprint to give more control over specifying elasticsearch endpoints

No longer has port hardcoded and can now accept multiple endpoints if necessary
